### PR TITLE
fix dockerfilebase image permissions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,3 @@
-
 version: 2.1
 orbs:
   node: circleci/node@2.0.1
@@ -9,10 +8,14 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init --recursive
-      - node/install-packages
+      #necessary when root privileges
+      - run: npm config set unsafe-perm true
+      - node/install-packages:
+          # use a different format while debugging ex: debug-vX
+          cache-version: v2
       - persist_to_workspace:
           root: .
-          paths: 
+          paths:
             - .
 
   lint:
@@ -25,8 +28,7 @@ jobs:
       - store_test_results:
           path: ./reports/linter
       - store_artifacts:
-          path: ./reports/linter    
-
+          path: ./reports/linter
 
   build:
     docker:
@@ -47,13 +49,13 @@ jobs:
       - run:
           name: ReBuild grpc for node
           command: npm install grpc --runtime=node
-      - run: 
+      - run:
           name: run jest test
           command: npm run test
       - store_test_results:
           path: ./reports/jest
       - store_artifacts:
-          path: ./reports/jest    
+          path: ./reports/jest
 
   mocha-tests:
     docker:
@@ -61,10 +63,10 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run: 
+      - run:
           name: Rebuild grpc for electron
           command: npm install grpc --runtime=electron --target=7.0.0
-      - run: 
+      - run:
           name: Run mocha test
           command: npm run mocha -- --reporter mocha-junit-reporter
       - store_test_results:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-ARG BASE_IMAGE=node
+ARG BASE_IMAGE=node:lts
+# use circleci/node when using this image on ci
 
 FROM ${BASE_IMAGE} as env-protoc
-WORKDIR /tmp
 ARG ARG_PROTOC_VERSION=3.7.1
 ENV PROTOC_VERSION=${ARG_PROTOC_VERSION}
 
 ENV PROTOC_ZIP=protoc-${ARG_PROTOC_VERSION}-linux-x86_64.zip
+USER root
 RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}
 RUN unzip -o ${PROTOC_ZIP} -d /usr/local bin/protoc
 RUN unzip -o ${PROTOC_ZIP} -d /usr/local 'include/*'


### PR DESCRIPTION
- fix dockerfile base image permission (needs root)
- once pushed on ci with `BASE_IMAGE=circleci/node`, it should fix cache problem:
the current ci cache problem is about the cache of symlink:
- currently only caching the symlink not the files attached to it
- using the `circleci` prebuilt image fix this behavior

PS: don't worry about ci not passing, using  `circleci/node` fix the issue, you can check this on [`pipeline #197`](https://app.circleci.com/pipelines/github/cryptogarageinc/p2pderivatives-client)