### PR TITLE
fix order in outcome merger

### DIFF
--- a/src/renderer/util/__tests__/outcome-merger.test.ts
+++ b/src/renderer/util/__tests__/outcome-merger.test.ts
@@ -28,6 +28,32 @@ describe('outcome merge tests', () => {
     expect(result[2].local).toBe(1)
   })
 
+  it('should merge numerical ranges with same outcomes if not ordered', () => {
+    const outcomes: Outcome[] = [
+      { message: '1', local: 1, remote: 0 },
+      { message: '3', local: 1, remote: 0 },
+      { message: '2', local: 1, remote: 0 },
+      { message: '4', local: 1, remote: 0 },
+      { message: '5', local: 0, remote: 1 },
+      { message: '6', local: 0, remote: 1 },
+      { message: '8', local: 0, remote: 1 },
+      { message: '7', local: 0, remote: 1 },
+      { message: '9', local: 1, remote: 0 },
+      { message: '10', local: 1, remote: 0 },
+      { message: '11', local: 1, remote: 0 },
+      { message: '12', local: 1, remote: 0 },
+    ]
+
+    const result = merge(outcomes)
+    expect(result.length).toBe(3)
+    expect(result[0].message).toBe('1-4')
+    expect(result[0].local).toBe(1)
+    expect(result[1].message).toBe('5-8')
+    expect(result[1].local).toBe(0)
+    expect(result[2].message).toBe('9-12')
+    expect(result[2].local).toBe(1)
+  })
+
   it('should merge numerical, but leave other values', () => {
     const outcomes: Outcome[] = [
       { message: '1', local: 1, remote: 0 },

--- a/src/renderer/util/outcome-merger.ts
+++ b/src/renderer/util/outcome-merger.ts
@@ -11,7 +11,7 @@ interface RangeOutcome {
 
 export const merge = (outcomes: Outcome[]): Outcome[] => {
   const stringOutcomes: Outcome[] = []
-  const numericalOutcomes: Outcome[] = []
+  let numericalOutcomes: Outcome[] = []
   outcomes.forEach(o => {
     if (isNaN(parseInt(o.message))) {
       stringOutcomes.push(o)
@@ -23,7 +23,9 @@ export const merge = (outcomes: Outcome[]): Outcome[] => {
 
   let resultOutcomes: Outcome[] = []
 
-  numericalOutcomes.sort(o => parseInt(o.message))
+  numericalOutcomes = numericalOutcomes.sort(
+    (a, b) => parseInt(a.message) - parseInt(b.message)
+  )
   let tempOutcome = outcomeToRangeOutcome(numericalOutcomes[0])
 
   for (let i = 1; i < numericalOutcomes.length; i++) {


### PR DESCRIPTION
Fix a bug in outcome merger where the output of the order function is not reassigned.