### PR TITLE
fix contract view for contracts with final outcome

### DIFF
--- a/src/renderer/components/organisms/ContractView/index.tsx
+++ b/src/renderer/components/organisms/ContractView/index.tsx
@@ -134,7 +134,7 @@ const ContractView: FC<ContractViewProps> = (props: ContractViewProps) => {
     props.cancel()
   }
 
-  const content: ContentType[] = [
+  let content: ContentType[] = [
     { title: 'State', value: ContractState[contract.state] },
     {
       title: 'Maturity Date',
@@ -163,7 +163,7 @@ const ContractView: FC<ContractViewProps> = (props: ContractViewProps) => {
       ? contract.finalOutcome.local - contract.localCollateral
       : contract.finalOutcome.remote - contract.remoteCollateral
 
-    content.concat([
+    content = content.concat([
       { title: 'Outcome Value', value: contract.finalOutcome.message },
       {
         title: 'Local Payout',


### PR DESCRIPTION
Fix bug where the output of the concat function is not reassigned so information for contract with final outcome is not displayed.