### PR TITLE
Fix btc/sats conversion

### DIFF
--- a/src/common/utils/__tests__/conversion.test.ts
+++ b/src/common/utils/__tests__/conversion.test.ts
@@ -1,0 +1,22 @@
+import { btcToSats, satsToBtc } from '../conversion'
+
+const testCases: { btc: number; sats: number }[] = [
+  { btc: 0.00001, sats: 1000 },
+  { btc: 0.00000001, sats: 1 },
+  { btc: 1.0, sats: 100000000 },
+  { btc: 4567.2340987, sats: 456723409870 },
+  { btc: 4567.23409871, sats: 456723409871 },
+]
+
+describe('btc conversions tests', () => {
+  it('should properly convert from btc to sats', () => {
+    for (const test of testCases) {
+      expect(btcToSats(test.btc)).toEqual(test.sats)
+    }
+  })
+  it('should properly convert from sats to btc', () => {
+    for (const test of testCases) {
+      expect(satsToBtc(test.sats)).toEqual(test.btc)
+    }
+  })
+})

--- a/src/common/utils/conversion.ts
+++ b/src/common/utils/conversion.ts
@@ -1,7 +1,9 @@
-const SatoshisInBtc = 100000000
-
 export function btcToSats(amount: number): number {
-  return amount * SatoshisInBtc
+  const btcString = amount.toString()
+  const parts = btcString.split('.')
+  let rightSide = parts.length == 2 ? parts[1] : ''
+  rightSide = rightSide.padEnd(8, '0')
+  return parseInt(parts[0] + rightSide)
 }
 
 export function satsToBtc(amount: number): number {


### PR DESCRIPTION
There was an error in the conversion  from btc to sats when the number was a decimal. Ended up doing the same as sats to btc, manipulating strings instead of numbers. Also added some tests to confirm it's working.