### PR TITLE
Fix/expired token dlc service

### DIFF
--- a/integration-test/run-separate/dlcManager.test.ts
+++ b/integration-test/run-separate/dlcManager.test.ts
@@ -19,6 +19,8 @@ import {
   getNewPartyContext,
   PartyContext,
 } from './integrationTestCommons'
+import { AuthenticationService } from '../../src/browser/api/grpc/AuthenticationService'
+import { GrpcAuth } from '../../src/browser/api/grpc/GrpcAuth'
 
 const localParty = 'alice'
 const remoteParty = 'bob'
@@ -491,7 +493,19 @@ function sendDlcMessageMock(
 }
 
 function getDlcMessageStreamMock(stream: Readable): DlcMessageStream {
-  return new DlcMessageStream(stream, () => {
-    // do nothing
-  })
+  const grpcAuth = new GrpcAuth()
+  grpcAuth.authorize('', 100000, '')
+  return new DlcMessageStream(
+    stream,
+    new AuthenticationService(
+      {
+        login: jest.fn(),
+        refresh: jest.fn(),
+        logout: jest.fn(),
+        updatePassword: jest.fn(),
+      },
+      grpcAuth
+    ),
+    jest.fn()
+  )
 }

--- a/src/browser/api/grpc/AuthenticationService.ts
+++ b/src/browser/api/grpc/AuthenticationService.ts
@@ -122,4 +122,8 @@ export class AuthenticationService {
     )
     return changePasswordAsync(cpRequest, metaData)
   }
+
+  public getGrpcAuth(): GrpcAuth {
+    return this._auth
+  }
 }

--- a/src/browser/api/grpc/GrpcClient.ts
+++ b/src/browser/api/grpc/GrpcClient.ts
@@ -35,7 +35,7 @@ export class GrpcClient {
     this._authService = new AuthenticationService(authClient, this._auth)
     const userClient = this.createClient<IUserClient>(UserClient, config)
     this._userService = new UserService(userClient, this._auth)
-    this._dlcService = new DlcMessageService(userClient, this._auth)
+    this._dlcService = new DlcMessageService(userClient, this._authService)
   }
 
   public getAuthObject(): GrpcAuth {

--- a/src/browser/dlc/models/contract/index.ts
+++ b/src/browser/dlc/models/contract/index.ts
@@ -13,6 +13,8 @@ import { RejectedContract } from './RejectedContract'
 import { SignedContract } from './SignedContract'
 import { UnilateralClosedByOtherContract } from './UnilateralClosedByOtherContract'
 import { UnilateralClosedContract } from './UnilateralClosedContract'
+import { StatelessContract } from './StatelessContract'
+import { ContractState, Contract } from '../../../../common/models/dlc/Contract'
 
 export { toAcceptMessage } from './AcceptedContract'
 export type { AcceptedContract } from './AcceptedContract'


### PR DESCRIPTION
Dlc service was not calling the refresh method before making request which means it was failing once the auth token was expired.