### PR TITLE
Fix/better peer errors

### DIFF
--- a/src/browser/dlc/utils/ContractUpdater.ts
+++ b/src/browser/dlc/utils/ContractUpdater.ts
@@ -98,7 +98,7 @@ export class ContractUpdater {
   }
 
   async toOfferedContract(
-    contract: InitialContract,
+    contract: InitialContract | AcceptedContract,
     localPartyInputs?: PartyInputs
   ): Promise<OfferedContract> {
     const collateral = contract.isLocalParty
@@ -106,6 +106,10 @@ export class ContractUpdater {
       : contract.remoteCollateral
     const commonFee = getCommonFee(contract.feeRate)
     let privateParams: PrivateParams | undefined = undefined
+
+    if ('remotePartyInputs' in contract) {
+      await this.unlockUtxos(contract)
+    }
 
     if (!localPartyInputs) {
       try {

--- a/src/browser/dlc/utils/DlcEventHandler.ts
+++ b/src/browser/dlc/utils/DlcEventHandler.ts
@@ -129,6 +129,21 @@ export class DlcEventHandler {
     return acceptedContract
   }
 
+  async onOfferAcceptFailed(contractId: string): Promise<OfferedContract> {
+    const acceptedContract = (await this.tryGetContractOrThrow(contractId, [
+      ContractState.Accepted,
+    ])) as AcceptedContract
+
+    const offeredContract = await this._contractUpdater.toOfferedContract(
+      acceptedContract,
+      acceptedContract.localPartyInputs
+    )
+
+    await this._dlcService.updateContract(offeredContract)
+
+    return offeredContract
+  }
+
   async onAcceptMessage(
     from: string,
     acceptMessage: AcceptMessage


### PR DESCRIPTION
Improve errors returned to user when the peer is not connected.

One thing that is not perfect is that now a contract cannot be rejected if the peer is not connected. It's not ideal, but making it perfect is too much work for now.