### PR TITLE
Fix db query for refundable contracts

### DIFF
--- a/src/browser/dlc/service/DlcService.ts
+++ b/src/browser/dlc/service/DlcService.ts
@@ -66,6 +66,7 @@ export class DlcService {
   getRefundableContracts(): Promise<AnyContract[]> {
     const query: ExtendedContractQuery = {
       maturedBefore: DateTime.utc().minus(RefundTimeout),
+      states: [ContractState.Confirmed],
     }
 
     return this._repository.getContracts(query)

--- a/src/browser/dlc/utils/ContractUpdater.ts
+++ b/src/browser/dlc/utils/ContractUpdater.ts
@@ -769,7 +769,7 @@ export class ContractUpdater {
   }
 
   async toRefundedContract(
-    contract: SignedContract
+    contract: ConfirmedContract
   ): Promise<RefundedContract> {
     const reqJson: cfddlcjs.AddSignaturesToRefundTxRequest = {
       refundTxHex: contract.refundTxHex,

--- a/src/browser/dlc/utils/DlcEventHandler.ts
+++ b/src/browser/dlc/utils/DlcEventHandler.ts
@@ -355,9 +355,8 @@ export class DlcEventHandler {
 
   async onContractRefund(contractId: string): Promise<Contract> {
     const contract = (await this.tryGetContractOrThrow(contractId, [
-      ContractState.Signed,
-      ContractState.Broadcast,
-    ])) as SignedContract
+      ContractState.Confirmed,
+    ])) as ConfirmedContract
 
     const refundedContract = await this._contractUpdater.toRefundedContract(
       contract


### PR DESCRIPTION
The query for refundable contract was taking everything after a given maturity date, but that meant everything including closed contracts. Now it considers only confirmed contracts.