### PR TITLE
Fix/error when no remote collateral

### DIFF
--- a/integration-test/run-separate/dlcEventHandler.test.ts
+++ b/integration-test/run-separate/dlcEventHandler.test.ts
@@ -509,6 +509,11 @@ describe('dlc-event-handler', () => {
     ).resolves.toBeDefined()
   })
 
+  test('19-no-remote-collateral-should-work', async () => {
+    const offerMessage = await sendOffer({ remoteCollateral: 0 })
+    await acceptOffer(offerMessage)
+  })
+
   async function sendOffer(
     params: {
       localContext?: PartyContext
@@ -521,8 +526,12 @@ describe('dlc-event-handler', () => {
   ): Promise<OfferMessage> {
     const localContext = params.localContext || localPartyContext
     const remoteContext = params.remoteContext || remotePartyContext
-    const localCollateral = params.localCollateral || 1 * oneBtc
-    const remoteCollateral = params.remoteCollateral || 1 * oneBtc
+    const localCollateral =
+      params.localCollateral === undefined ? 1 * oneBtc : params.localCollateral
+    const remoteCollateral =
+      params.remoteCollateral === undefined
+        ? 1 * oneBtc
+        : params.remoteCollateral
     const outcomes = params.outcomes || baseOutcomes
     const premiumAmount = params.premiumAmount || 0
     const contract: Contract = {

--- a/integration-test/run-separate/dlcManager.test.ts
+++ b/integration-test/run-separate/dlcManager.test.ts
@@ -173,27 +173,27 @@ describe('dlc-manager', () => {
     remotePartyManager.finalize()
   })
 
-  test('19-mutual-closing-both-send', async () => {
+  test('20-mutual-closing-both-send', async () => {
     const contractId = await commonTests()
     await bothReceiveMutualClose(contractId)
   })
 
-  test('20-mutual-closing-local-send', async () => {
+  test('21-mutual-closing-local-send', async () => {
     const contractId = await commonTests()
     await onlyLocalSendsMutualClosing(contractId)
   })
 
-  test('21-unilateral-close-by-local', async () => {
+  test('22-unilateral-close-by-local', async () => {
     const contractId = await commonTests()
     await unilateralCloseFromLocal(contractId)
   })
 
-  test('22-unilateral-close-by-remote', async () => {
+  test('23-unilateral-close-by-remote', async () => {
     const contractId = await commonTests()
     await unilateralCloseFromRemote(contractId)
   })
 
-  test('23-unilateral-close-by-local-after-timeout', async () => {
+  test('24-unilateral-close-by-local-after-timeout', async () => {
     const contractId = await commonTests()
     await unilateralCloseFromLocalAfterProposeTimeout(contractId)
   })

--- a/integration-test/run-separate/run.sh
+++ b/integration-test/run-separate/run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-for i in {1..23}
+for i in {1..24}
 do
   docker-compose up -d bitcoind
   jest --config jest.config.integration-separate.js --reporters=default --runInBand -t=" $i-"

--- a/src/browser/dlc/utils/ContractUpdater.ts
+++ b/src/browser/dlc/utils/ContractUpdater.ts
@@ -104,7 +104,7 @@ export class ContractUpdater {
     const collateral = contract.isLocalParty
       ? contract.localCollateral
       : contract.remoteCollateral
-    const commonFee = getCommonFee(contract.feeRate)
+    const halfCommonFee = Math.ceil(getCommonFee(contract.feeRate) / 2)
     const premiumAmount = contract.premiumAmount || 0
     let privateParams: PrivateParams | undefined = undefined
 
@@ -115,7 +115,7 @@ export class ContractUpdater {
     if (!localPartyInputs) {
       try {
         const utxos = await this.walletClient.getUtxosForAmount(
-          collateral + commonFee + premiumAmount,
+          collateral + halfCommonFee + premiumAmount,
           contract.feeRate
         )
         privateParams = await this.getNewPrivateParams(utxos)
@@ -148,8 +148,9 @@ export class ContractUpdater {
     let privateParams = contract.privateParams
     if (!remotePartyInputs || !privateParams) {
       try {
+        const halfCommonFee = Math.ceil(getCommonFee(contract.feeRate) / 2)
         const utxos = await this.walletClient.getUtxosForAmount(
-          contract.remoteCollateral,
+          contract.remoteCollateral + halfCommonFee,
           contract.feeRate
         )
         privateParams = await this.getNewPrivateParams(utxos)


### PR DESCRIPTION
Coin selection for remote party didn't take into account the common fee which led to an exception being thrown when DLC transactions were created. 